### PR TITLE
Add support for Apple MPS in MNIST training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+experiments/
+data/
+FGS_test

--- a/train_mnist.py
+++ b/train_mnist.py
@@ -150,7 +150,7 @@ def main(_):
     filename = os.path.join(cwd,"CNN_MNIST.pth")
     torch.save(net.state_dict(),filename)
 
-    print(f'\nTraining MNIST took: {round(time.time()-start,2)} s')
+    print(f'\nTraining MNIST on torch.device({DEVICE}) took: {round(time.time()-start,2)} s')
 
 if __name__ == "__main__":
     flags.DEFINE_integer("nb_epochs", 8, "Number of epochs.")

--- a/train_mnist.py
+++ b/train_mnist.py
@@ -87,6 +87,16 @@ def ld_mnist(batch_size=128, transform=None,shuffle=True):
     return EasyDict(train=train_loader, test=test_loader)
 
 
+def mps_enabled() -> bool:
+    """
+    - checks if the current system has support for the Metal programming framework, which allows GPU acceleration in ML applications, such as DNN
+    """
+    platform = os.uname().sysname.strip().lower() # check if current platform is macOS specific (i.e., Darwin)
+    if "darwin" not in platform or not torch.backends.mps.is_available() or not torch.backends.mps.is_built():
+        return False
+    return True
+
+
 def main(_):
     start = time.time()
     # Load training and test data
@@ -95,8 +105,7 @@ def main(_):
     # Instantiate model, loss, and optimizer for training
     net = PyNet(in_channels=1)
 
-    platform = os.uname().sysname.strip().lower() # check if current platform is macOS specific (i.e., Darwin)
-    if "darwin" in platform and torch.backends.mps.is_available():
+    if mps_enabled():
         print('Detected Darwin platform with MPS device...')
         DEVICE = "mps"
     elif torch.cuda.is_available():

--- a/train_mnist.py
+++ b/train_mnist.py
@@ -21,6 +21,8 @@ from cleverhans.torch.attacks.projected_gradient_descent import (
     projected_gradient_descent,
 )
 
+import time
+
 import os
 FLAGS = flags.FLAGS
 
@@ -86,6 +88,7 @@ def ld_mnist(batch_size=128, transform=None,shuffle=True):
 
 
 def main(_):
+    start = time.time()
     # Load training and test data
     data = ld_mnist()
 
@@ -146,9 +149,9 @@ def main(_):
     # save model
     filename = os.path.join(cwd,"CNN_MNIST.pth")
     torch.save(net.state_dict(),filename)
-    
+
+    print(f'\nTraining MNIST took: {round(time.time()-start,2)} s')
 
 if __name__ == "__main__":
     flags.DEFINE_integer("nb_epochs", 8, "Number of epochs.")
-
     app.run(main)


### PR DESCRIPTION
This pull request adds support for the Metal framework that allows ML acceleration while using Apple GPUs (on ARM devices, such as M1, M2, M3, and their variants). Using [MPS](https://pytorch.org/docs/stable/notes/mps.html) has a benefit in the execution time as compared to the CPU, and since MacBooks do not have support for CUDA, this presents itself as an effective alternative.

A simple comparison between GPU and CPU on Pytorch version `2.3.1` shows roughly a **8X** performance improvement on the `train_mnist.py` example. More precisely, on 8 epochs, the execution times are:
**GPU**: `37.7 s`
**CPU**: `299.27 s`

*(Tested on M3 Pro with Python `3.11.9`)*

### Changes to `mtd.py`

The module has been updated to support MPS as a device, but also avoid any hard-coded CUDA specific values (except for the tensor perturbation procedure from `perturb_weights_and_retrain()`). The motivation behind this refactoring was due to the `generate_students.py` script being unable to execute on a system without CUDA support (that is no NVIDIA GPU).

Previously, there were several `model.cuda()` calls that were making the execution problematic. This was fixed by adding the global variable `DEVICE`, which can be `cuda`, `mps`, or `cpu`, depending on the conditions. See here:
```python
# Create execution device. the global device will be denoted by all uppercase letters
# a device that is locally defined inside a method will be lowercase
if torch.cuda.is_available():
    DEVICE = "cuda"
    torch.backends.cudnn.benchmark = True
elif mps_enabled():
    DEVICE = "mps"
else:
    DEVICE = "cpu"
```

* Moreover, the tensors are safely copied on the proper device, including the one generated using numpy's `np.random.laplace`. In this case, if the device is not the default `CPU`, then `torch.tensor()` needs to be wrapped around. Be aware that the `dtype` has been changed to `torch.float32` in order for MPS to work, avoiding the following error:
```bash
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```
* The arguments of `retrain()` method were left unchanged, meaning that the `device` attribute must still be specified, and all the model operations within the scope of the method will be relative to that device (and not the global `DEVICE`). Although, it would make sense to just use the global one at some point in the future.
* The `load_model()` method has been updated with a new attribute: `device` (see below). This change was made because previously, it was *forcing* a `model.cuda()` within the scope of the method. This was relaxed with the `model.to(device)` statement.
```python
def load_model(device,dir_path,ind,adv_train=False,model_type='mtd',copycat=False):
    """
    - load the model
    - param `device`: `str` is required
    """
    ...
    model.to(device) # load the model onto custom device
    ...
```

